### PR TITLE
Hide the spawned terminal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,9 @@ export default class SysTray extends EventEmitter {
     super()
     this._conf = conf
     this._binPath = getTrayBinPath(conf.debug, conf.copyDir)
-    this._process = child.spawn(this._binPath)
+    this._process = child.spawn(this._binPath, [], {
+      windowsHide: true
+    })
     this._rl = readline.createInterface({
       input: this._process.stdout,
     })


### PR DESCRIPTION
If one creates a standalone executable that doesn't render a terminal, not specifying `windowsHide: true` would still pop up a terminal. At least on Windows.
This way, one can actually distribute executables that only show the tray icon.